### PR TITLE
Handle null MMSI identifiers in stats computation

### DIFF
--- a/aistk/backends/dask_backend.py
+++ b/aistk/backends/dask_backend.py
@@ -82,7 +82,11 @@ def _per_mmsi(pdf: pd.DataFrame) -> pd.DataFrame:
     if "ts" in pdf.columns:
         pdf = pdf.sort_values("ts", kind="mergesort")
 
-    mmsi_val = int(pdf["MMSI"].iloc[0]) if "MMSI" in pdf.columns and len(pdf["MMSI"]) else np.nan
+    mmsi_val = np.nan
+    if "MMSI" in pdf.columns and len(pdf["MMSI"]):
+        first_mmsi = pdf["MMSI"].iloc[0]
+        if not pd.isna(first_mmsi):
+            mmsi_val = int(first_mmsi)
     points = int(len(pdf))
 
     if "LAT" not in pdf.columns or "LON" not in pdf.columns or points < 2:

--- a/aistk/stats.py
+++ b/aistk/stats.py
@@ -119,7 +119,13 @@ def compute_stats_df(df: pl.DataFrame, level: AggLevel = "mmsi") -> pl.DataFrame
         # Polars GroupBy is iterable: (key, subframe)
         for _key, pdf in df.group_by("MMSI", maintain_order=True):
             stats = _per(pdf)
-            stats["MMSI"] = int(pdf["MMSI"][0])
+            first_mmsi = pdf["MMSI"][0]
+            if first_mmsi is None or (
+                isinstance(first_mmsi, (float, np.floating)) and np.isnan(first_mmsi)
+            ):
+                stats["MMSI"] = None
+            else:
+                stats["MMSI"] = int(first_mmsi)
             rows.append(stats)
         return pl.DataFrame(rows)
 

--- a/tests/test_backends_dask.py
+++ b/tests/test_backends_dask.py
@@ -1,5 +1,6 @@
-import pytest
+import numpy as np
 import pandas as pd
+import pytest
 
 dd = pytest.importorskip("dask.dataframe", reason="dask not installed; skipping dask backend tests")
 
@@ -19,3 +20,21 @@ def test_compute_stats_dask_smoke():
     out = compute_stats_dask(ddf, level="mmsi")
     assert not out.empty
     assert "distance_km" in out.columns
+
+
+def test_compute_stats_dask_handles_nan_mmsi():
+    pdf = pd.DataFrame(
+        {
+            "MMSI": [np.nan, np.nan, 123456789],
+            "LAT": [10.0, 10.001, 10.002],
+            "LON": [20.0, 20.001, 20.002],
+            "ts": pd.date_range("2024-01-01", periods=3, freq="5min"),
+        }
+    )
+
+    ddf = dd.from_pandas(pdf, npartitions=2)
+    out = compute_stats_dask(ddf, level="mmsi")
+
+    nan_rows = out[out["MMSI"].isna()]
+    assert not nan_rows.empty
+    assert int(nan_rows["points"].iloc[0]) == 2

--- a/tests/test_stats.py
+++ b/tests/test_stats.py
@@ -32,3 +32,18 @@ def test_compute_stats_handles_all_null_sog():
     assert stats.height == 1
     assert stats["max_sog"][0] is None
     assert stats["avg_sog"][0] is None
+
+
+def test_compute_stats_df_handles_null_mmsi():
+    df = pl.DataFrame(
+        {
+            "MMSI": pl.Series("MMSI", [None, 999_999_999], dtype=pl.Int64),
+            "LAT": [30.0, 30.001],
+            "LON": [-40.0, -39.999],
+        }
+    )
+
+    stats = compute_stats_df(df, level="mmsi")
+
+    assert stats.height == 2
+    assert stats["MMSI"][0] is None


### PR DESCRIPTION
## Summary
- guard MMSI extraction in the Dask backend so null identifiers remain missing
- ensure the Polars stats helper preserves null MMSI values when grouping
- cover both code paths with regression tests for null MMSI inputs

## Testing
- PYTHONPATH=. pytest tests/test_backends_dask.py::test_compute_stats_dask_handles_nan_mmsi tests/test_stats.py::test_compute_stats_df_handles_null_mmsi


------
https://chatgpt.com/codex/tasks/task_e_68d3d1b5696c832285092e59986309c6