### PR TITLE
Install pytest in CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,7 @@ jobs:
           python -m pip install --upgrade pip
           pip install ".[viz,cli]"
           pip install "dask[dataframe]" pyarrow shapely h3
+          pip install pytest
 
       - name: Run tests
         run: pytest


### PR DESCRIPTION
## Summary
- install pytest in the GitHub Actions job so the `pytest` command is available when tests run

## Testing
- pytest *(fails locally: missing package `aistk` because editable install was not performed in the offline environment)*
